### PR TITLE
Only load inputenc when pdftex is used.

### DIFF
--- a/adsphd.cls
+++ b/adsphd.cls
@@ -33,6 +33,7 @@
 
 % Different actions when using pdflatex
 \RequirePackage{ifpdf}
+\RequirePackage{iftex}
 
 \RequirePackage[usenames]{color}
 
@@ -483,9 +484,13 @@
 
 \RequirePackage{framed} % voor shaded environment
 
+
+
 \ifadsphd@biblatex
     \typeout{adsphd.cls: Using biblatex}
-    \RequirePackage[utf8]{inputenc}
+    \ifPDFTeX
+      \RequirePackage[utf8]{inputenc}
+    \fi
     \RequirePackage{csquotes}
     \RequirePackage[hyperref=auto]{biblatex}
     %\RequirePackage[hyperref=auto,mincrossrefs=999]{biblatex}
@@ -524,7 +529,9 @@
   \RequirePackage[pdftex]{graphicx}
   \DeclareGraphicsExtensions{.pdf, .jpg, .tif, .png}
   % Use utf-8 encoding for foreign characters
-  \RequirePackage[utf8]{inputenc}
+    \ifPDFTeX
+      \RequirePackage[utf8]{inputenc}
+    \fi
 \else
   % Load the crop package
   \RequirePackage[center,dvips]{crop} % Option [a3] already passed


### PR DESCRIPTION
Only load inputenc when pdftex is used. Lualatex and XeLaTeX don't need it, and don't like it when that package is loaded. I was helping someone use the Linux Libertine font in his PhD text, and inputenc caused an error with the font specific microtype configuration file. The change corresponds to the following solution: http://tug.org/pipermail/luatex/2010-October/002184.html.
