### PR TITLE
Fixed incomplete command.

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -77,7 +77,7 @@
 \makeatother
 \makenomenclature
 
-% for the list of abbreviations. 
+% for the list of abbreviations.
 \newcommand{\glossname}{Abbreviations}
 \makeglossary
 
@@ -98,7 +98,7 @@
 %\bibstyle{ieeetr}
 
 % Own commands
-\InputIfFileExists{defs} % defs.tex, contains own preamble settings
+\InputIfFileExists{defs}{}{} % defs.tex, contains own preamble settings
 
 % }{}}}  <-- Preamble
 


### PR DESCRIPTION
The InputIfFileExists command takes 3 arguments. Not adding the last two (empty) braces makes certain commands break the compilation in certain cases (e.g. loadglsentries from the glossaries package).
