### PR TITLE
Change in default phddegree value

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -35,7 +35,7 @@
 }
 \externaljurymember{Prof.~dr.~Het~extern~jurylid}{Ver weg}
 
-\phddegree{Engineering} % "Doctor of ..."
+\phddegree{Engineering Science: Computer Science} % "Doctor of ..."
 \faculty{Faculty of Engineering Science}
 \department{Department of Computer Science}
 \researchgroup{Scientific Computing Group}


### PR DESCRIPTION
I've changed the default degree.  According to https://onderwijsaanbod.kuleuven.be/2014/opleidingen/e/SC_50046650.htm
and ADS our diploma's now read "Doctor in Engineering Science: Some
Topic".  Where Some Topic is for example Computer Science, Mechanical
Engineering or Electrical Engineering.
