### PR TITLE
Switching from 'glossary' package to 'glossaries', from '\include' to '\input' and correcting the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Options for the adsphd class
                             show some info (compilation time, ...)
     draft                 : show info and compile the document as a
                             draft
-    prelim                : generate a version of the document
+    prelim               : generate a version of the document
                             suitable to send to the jury. This means
                             that the logical page is put on an A4
                             without info, frame, todos, ... 
@@ -192,13 +192,13 @@ Chapters
 
 **Inclusion of normal chapters**
 
-Use the command `\includechapter{.}`, e.g., 
+Use the command `\inputchapter{.}`, e.g., 
 
-    \includechapter{introduction}
+    \inputchapter{introduction}
 
 includes `./chapters/introduction/introduction.tex`.
 
-If the chapter is an appendix, use `\includeappendix{.}`!
+If the chapter is an appendix, use `\inputappendix{.}`!
 
 
 **Inclusion of 'special' chapters**
@@ -214,12 +214,12 @@ The term 'special' chapters refers to the
 
 To include any of the above, use the command
 
-    \includeXXX{filename}
+    \inputXXX{filename}
 
 where `XXX` stands for the name indicated in between brackets above, and filename
-is as in the \includechapter command. For instance,
+is as in the \inputchapter command. For instance,
 
-    \includeappendix{myappendix} % includes ./chapters/myappendix/myappendix.tex as an appendix
+    \inputappendix{myappendix} % includes ./chapters/myappendix/myappendix.tex as an appendix
 
 Other special chapters are
 
@@ -230,7 +230,7 @@ Other special chapters are
 
 but these different from the above as they are generated using standard
 commands (`\listoffigures`, `\listoftables`, `\tableofcontents`,
-`\includebibliography`).
+`\inputbibliography`).
 
 For typical usage, see the provided file `thesis.tex`.
 
@@ -252,9 +252,9 @@ Troubleshooting
 
 * To be able to make the chapter compilation work, you should make sure that
   the desired chapter is included in thesis.tex (e.g., using
-  `\includechapter{introduction})`!!
+  `\inputchapter{introduction})`!!
 * If you get spurious empty pages when compiling a single chapter, this is
-  probably due to the combination of `\cleardoublepage` and `\includeonly`. To
+  probably due to the combination of `\cleardoublepage` and `\inputonly`. To
   avoid it, make sure you end all included chapters (and appendices) with
   `\cleardoublepage` (if you use `makeemptychapter.sh` to generate the chapter
   skeleton this is automatically done!)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Options for the adsphd class
                             show some info (compilation time, ...)
     draft                 : show info and compile the document as a
                             draft
-    prelim               : generate a version of the document
+    tothejury          : generate a version of the document
                             suitable to send to the jury. This means
                             that the logical page is put on an A4
                             without info, frame, todos, ... 
@@ -302,6 +302,7 @@ Marko van Dooren,
 Rutger Claes,
 Dirk Van Hertem,
 Anthony Van Herrewege.
+Tassos Natsakis
 
 
 ----

--- a/adsphd.cls
+++ b/adsphd.cls
@@ -222,6 +222,9 @@
   \adsphd@infofalse
   \adsphd@showinstructionsfalse
   \adsphd@framefalse
+
+  %disable TODOs
+  \PassOptionsToPackage{disable}{todonotes}
 \fi
 
 \ifadsphd@draft

--- a/adsphd.cls
+++ b/adsphd.cls
@@ -806,7 +806,7 @@
 \newlength{\@chaptitlemoveup}
 \newcommand{\chaptitlemoveup}[1]{\setlength{\@chaptitlemoveup}{#1}}
 
-\newcommand{\IncludeUnnumberedChapterIfExists}[4]{%
+\newcommand{\inputUnnumberedChapterIfExists}[4]{%
   \typeout{adsphd.cls: chapter `#1'}
   \cleardoublepage
   #4
@@ -817,7 +817,7 @@
       \global\@topnum\z@
       \@afterindentfalse
       \secdef\@nonumberchapter\@snonumberchapter}
-    \include{\chaptersdir/#1/#1}
+    \input{\chaptersdir/#1/#1}
     \let\chapter=\orig@chapter
   }{
     \chapter*{#2}
@@ -829,49 +829,49 @@
   }
 }
 
-\newcommand{\includechapter}[1]{%
+\newcommand{\inputchapter}[1]{%
   \graphicspath{{\chaptersdir/#1/image/}}%
   %\cleardoublepage%
-  \include{\chaptersdir/#1/#1}%
+  \input{\chaptersdir/#1/#1}%
 }
 
-\newcommand{\includepreface}[1]{%
-  \IncludeUnnumberedChapterIfExists{#1}{\prefname}{\instructionspreface}%
+\newcommand{\inputpreface}[1]{%
+  \inputUnnumberedChapterIfExists{#1}{\prefname}{\instructionspreface}%
       {\phantomsection}
 }
 
-\newcommand{\includeprefacenl}[1]{%
+\newcommand{\inputprefacenl}[1]{%
   \selectlanguage{dutch}
-  \IncludeUnnumberedChapterIfExists{#1}{\prefnlname}{\instructionspreface}
+  \inputUnnumberedChapterIfExists{#1}{\prefnlname}{\instructionspreface}
         {\phantomsection}
   \selectlanguage{english}
 }
 
-\newcommand{\includeabstract}[1]{%
-  \IncludeUnnumberedChapterIfExists{#1}{\abstractname}{\instructionsabstract}
+\newcommand{\inputabstract}[1]{%
+  \inputUnnumberedChapterIfExists{#1}{\abstractname}{\instructionsabstract}
         {\phantomsection}
 }
 
-\newcommand{\includeabstractnl}[1]{%
+\newcommand{\inputabstractnl}[1]{%
   \selectlanguage{dutch}
-  \IncludeUnnumberedChapterIfExists{#1}{\abstractnlname}{\instructionsabstract}
+  \inputUnnumberedChapterIfExists{#1}{\abstractnlname}{\instructionsabstract}
         {\phantomsection}
   \selectlanguage{english}
 }
 
-\newcommand{\includeabbreviations}[1]{%
+\newcommand{\inputabbreviations}[1]{%
   % Use this command when making the abbreviation manually. Using the
-  \IncludeUnnumberedChapterIfExists{#1}{Abbreviations}{\instructionslistofsymbols}{}
+  \inputUnnumberedChapterIfExists{#1}{Abbreviations}{\instructionslistofsymbols}{}
 }
 
-\newcommand{\includenomenclature}[1]{%
+\newcommand{\inputnomenclature}[1]{%
   % Use this command when making the nomenclature manually. Using the
   % nomencl package might be a better idea though...
-  \IncludeUnnumberedChapterIfExists{#1}{\nomname}{\instructionslistofsymbols}{}
+  \inputUnnumberedChapterIfExists{#1}{\nomname}{\instructionslistofsymbols}{}
 }
 
 \ifadsphd@biblatex
-  \newcommand{\includebibliography}{%
+  \newcommand{\inputbibliography}{%
     \@ifnextchar \bgroup{\ClassError{adsphd}{%
       Biblatex expects the bib-file in the preamble}{%
       Don't pass an argument to the includebibliography command
@@ -888,12 +888,12 @@
   }
 \else
   \ifadsphd@custombibtex
-    \newcommand{\includebibliography}{%
+    \newcommand{\inputbibliography}{%
       \message{adsphd.cls: includebiblography command is not defined
       because of the custombibtex setting.}
     }
   \else
-    \newcommand{\includebibliography}{%
+    \newcommand{\inputbibliography}{%
       \cleardoublepage
       \phantomsection
       \addcontentsline{toc}{chapter}{\bibname}
@@ -942,12 +942,12 @@
   \listoftablesorig
 }
 
-\newcommand{\includeappendix}[1]{%
+\newcommand{\inputappendix}[1]{%
   \typeout{adsphd.cls: chapter `#1'}
   \cleardoublepage
   \IfFileExists{\chaptersdir/#1/#1.tex}{
     \graphicspath{{\chaptersdir/#1/image/}}%
-    \include{\chaptersdir/#1/#1}
+    \input{\chaptersdir/#1/#1}
   }{
     \chapter{#1}
     {\textcolor{red}{Input file \chaptersdir/#1/#1.tex does not exist.
@@ -955,13 +955,13 @@
   }
 }
 
-\newcommand{\includecv}[1]{%
-  \IncludeUnnumberedChapterIfExists{#1}{\cvname}{\instructionscv}%
+\newcommand{\inputcv}[1]{%
+  \inputUnnumberedChapterIfExists{#1}{\cvname}{\instructionscv}%
         {\phantomsection}
 }
 
-\newcommand{\includepublications}[1]{%
-  \IncludeUnnumberedChapterIfExists{#1}{\pubname}%
+\newcommand{\inputpublications}[1]{%
+  \inputUnnumberedChapterIfExists{#1}{\pubname}%
         {\instructionslistofpublications}{\phantomsection}
 }
 

--- a/adsphd.cls
+++ b/adsphd.cls
@@ -221,6 +221,7 @@
   \typeout{Creating A4 output for the version to send to the jury!!!}
   \adsphd@infofalse
   \adsphd@showinstructionsfalse
+  \adsphd@framefalse
 \fi
 
 \ifadsphd@draft

--- a/thesis.tex
+++ b/thesis.tex
@@ -119,13 +119,13 @@
 
 \frontmatter % to get \pagenumbering{roman}
 
-\includepreface{preface}
-\includeabstract{abstract}
-\includeabstractnl{abstractnl}
+\inputpreface{preface}
+\inputabstract{abstract}
+\inputabstractnl{abstractnl}
 
 % To create a list of abbreviations, there are 2 options
 % 1. manual creation and inclusion of this file
-%    \includeabbreviations{abbreviations}
+%    \inputabbreviations{abbreviations}
 % 2. automatic generation via the glossary package
 %    \usepackage{glossary}
 %    \makeglossary
@@ -135,7 +135,7 @@
 
 % To create a list of symbols, there are 2 options
 % 1. include a manually created nomenclature as a chapter
-%    \includenomenclature{nomenclaturechapter}
+%    \inputnomenclature{nomenclaturechapter}
 % 2. automatic generation via the nomencl package
 %    \usepackage{nomencl}
 %    \makenomenclature
@@ -158,31 +158,31 @@
 % Show instructions on a separate page
 \instructionschapters\cleardoublepage
 
-\includechapter{introduction}
-\includechapter{manual} % Remove this chapter
+\inputchapter{introduction}
+\inputchapter{manual} % Remove this chapter
 
 % Insert here your own chapters
 % Chapters are expected to be in a tex-file with the given name dot
 % tex and in a directory with the given name in the chapters
 % directory.
 
-\includechapter{conclusion}
+\inputchapter{conclusion}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \appendix
 
-\includeappendix{myappendix}
+\inputappendix{myappendix}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \backmatter
 
-\includebibliography
+\inputbibliography
 \instructionsbibliography
 
-\includecv{curriculum}
+\inputcv{curriculum}
 
-\includepublications{publications}
+\inputpublications{publications}
 
 %\makebackcoverX
 \makebackcoverXII

--- a/thesis.tex
+++ b/thesis.tex
@@ -12,7 +12,7 @@
 \usepackage[english,dutch]{babel}
 
 \usepackage{nomencl}   % For nomenclature
-\usepackage[style=long,number=none]{glossary} % For list of abbreviations
+\usepackage[style=long,nonumberlist,xindy]{glossaries} % For list of abbreviations
 
 % !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 % !!                                                               !!
@@ -80,7 +80,7 @@
 
 % for the list of abbreviations.
 \newcommand{\glossname}{Abbreviations}
-\makeglossary
+\makeglossaries
 
 % To avoid problems, do NOT change the layout of the following two
 % commands
@@ -131,7 +131,7 @@
 %    \makeglossary
 %    \glossary{name=MD,description=molecular dynamics}
 %    \printglossary
-\printglossary
+\printglossaries
 
 % To create a list of symbols, there are 2 options
 % 1. include a manually created nomenclature as a chapter


### PR DESCRIPTION
I made three commits, each fixing one of the following:

- I changed all the \include commands in favour of \input, as it allows nesting two levels of files. Therefore it is possible to \input tables or other files inside each chapter.
- I switched from the 'glossary' package to the newer 'glossaries'
- I fixed a small problem with the README file and the 'prelim/tothejury' options of the class