### PR TITLE
Fix warnings about deprecated commands and options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 chapters/*/Makefile
 chapters/*/*.aux
+chapters/*/*.log
 defs.tex
 q.tex
 thesis.aux
@@ -20,6 +21,12 @@ thesis.glo
 thesis.glg
 thesis.gls
 thesis.ist
+thesis.bcf
+thesis.glsdefs
+thesis.idx
+thesis.ind
+thesis.run.xml
+thesis.synctex.gz
 thesis.ps
 cover.*
 s

--- a/adsphd.cls
+++ b/adsphd.cls
@@ -616,12 +616,12 @@
 \renewcommand{\chaptermark}[1]{\markboth{\uppercase{#1}}{\uppercase{#1}}}
 \renewcommand{\sectionmark}[1]{\markright{\uppercase{#1}}}
 \fancyhf{}
-\fancyhead[RO]{\scriptsize\sf\rightmark\ \hrulefill\ \thepage}
-\fancyhead[RE]{\scriptsize\sf\thepage\ \hrulefill\ \leftmark}
+\fancyhead[RO]{\scriptsize\sffamily\rightmark\ \hrulefill\ \thepage}
+\fancyhead[RE]{\scriptsize\sffamily\thepage\ \hrulefill\ \leftmark}
 \renewcommand{\headrulewidth}{0pt}
 \fancypagestyle{plain}{
 \fancyhf{}
-\fancyfoot[C]{\scriptsize\sf\thepage}
+\fancyfoot[C]{\scriptsize\sffamily\thepage}
 \renewcommand{\headrulewidth}{0pt}
 \renewcommand{\footrulewidth}{0pt}
 }
@@ -1253,7 +1253,7 @@ De appendices kunnen desgevallend worden gebundeld in een apart boekdeel.
   \typeout{adsphd: Cover, smaller font size to fit doctoral school name}
   \fontsize{10}{13}\selectfont%
   \fi
-  {\bf \textcolor{white} {\sffamily \expandafter\MakeUppercase\expandafter{\@doctoralschool}}}\\[.2mm]
+  {\bfseries \textcolor{white} {\sffamily \expandafter\MakeUppercase\expandafter{\@doctoralschool}}}\\[.2mm]
   {\sffamily \textcolor{white} {\@faculty}}
   \end{flushright}
   \end{textblock*}
@@ -1284,7 +1284,7 @@ De appendices kunnen desgevallend worden gebundeld in een apart boekdeel.
   \vspace{-\parskip}
   \hspace*{2mm}
   \parbox[c][20mm]{97.92mm}{
-  {\bf \small \textcolor{white} {\sffamily Arenberg Doctoral School of Science, Engineering \& Technology}}\\[.2mm]
+  {\bfseries \small \textcolor{white} {\sffamily Arenberg Doctoral School of Science, Engineering \& Technology}}\\[.2mm]
   {\sffamily\small \textcolor{white} {\@faculty}}\\[.2mm]
   {\sffamily\small \textcolor{white} {\@department}}
   }
@@ -1726,7 +1726,7 @@ without written permission from the publisher.
   \parbox[c][20mm]{151.2mm+\rbleed}{
   \flushright
   \vspace{-3mm}
-  {\bf \scriptsize \textcolor{white} {\sffamily{}Arenberg Doctoral School of Science, Engineering \& Technology} \ \ }\\[-1mm]
+  {\bfseries \scriptsize \textcolor{white} {\sffamily{}Arenberg Doctoral School of Science, Engineering \& Technology} \ \ }\\[-1mm]
   {\scriptsize \textcolor{white} {\sffamily\@faculty\ \ }}\\[-1.2mm]
   {\scriptsize \textcolor{white} {\sffamily\@department \ \ }}\\[-1.2mm]
   {\scriptsize \textcolor{white} {\sffamily\@researchgroup\ \ }}\\[-1.2mm]

--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -2,8 +2,14 @@
 
 \ProvidesFile{biblatex.cfg}
 
+\@ifpackagelater{biblatex}{2016/03/01}{
+    \ExecuteBibliographyOptions{giveninits=true}
+}{
+    \ExecuteBibliographyOptions{firstinits=true}
+}
+
+
 \ExecuteBibliographyOptions{%
-	firstinits=true,%
 	uniquename=init,%
 	maxbibnames=99,%
 	maxcitenames=2,%


### PR DESCRIPTION
The biblatex option firstinits, and the commands \bf and \sf are deprecated. This results in warnings when using new versions of biblatex and/or the package 'nag'. The changes below fix these problems.

I've also added some more temporary files to .gitignore that are created when compiling with texstudio.