### PR TITLE
Set root document

### DIFF
--- a/chapters/abstract/abstract.tex
+++ b/chapters/abstract/abstract.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter{Abstract}                                 \label{ch:abstract}
 
 \ldots

--- a/chapters/abstractnl/abstractnl.tex
+++ b/chapters/abstractnl/abstractnl.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter{Beknopte samenvatting}
 
 \ldots

--- a/chapters/conclusion/conclusion.tex
+++ b/chapters/conclusion/conclusion.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter{This is conclusion}\label{ch:conclusion}
 
 \ldots

--- a/chapters/curriculum/curriculum.tex
+++ b/chapters/curriculum/curriculum.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter{This is curriculum}\label{ch:curriculum}
 
 \ldots

--- a/chapters/introduction/introduction.tex
+++ b/chapters/introduction/introduction.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter{This is introduction}\label{ch:introduction}
 
 \instructionsintroduction

--- a/chapters/makeemptychapter.sh
+++ b/chapters/makeemptychapter.sh
@@ -21,6 +21,7 @@ mkdir -p $CHAPTERNAME
 
 echo "Creating $CHAPTERNAME/$CHAPTERNAME.tex..."
 f=$CHAPTERNAME/$CHAPTERNAME.tex
+echo "% !TeX root = ../../thesis.tex" > $f
 echo "\\chapter{This is $CHAPTERNAME}\\label{ch:$CHAPTERNAME}" > $f
 echo "" >> $f
 echo "\\ldots" >> $f

--- a/chapters/manual/manual.tex
+++ b/chapters/manual/manual.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter{Manual}\label{ch:manual}
 
 

--- a/chapters/myappendix/myappendix.tex
+++ b/chapters/myappendix/myappendix.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter{This is myappendix}\label{ch:myappendix}
 
 \ldots

--- a/chapters/preface/preface.tex
+++ b/chapters/preface/preface.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../../thesis.tex
 \chapter*{Preface}                                  \label{ch:preface}
 
 \ldots

--- a/run.py
+++ b/run.py
@@ -280,13 +280,14 @@ def newchapter():
 	validchaptername = re.compile(r'^[a-zA-Z0-9_.]+$')
 	while validchaptername.match(chaptername) == None:
 		chaptername = input("New chapter file name (only a-z, A-Z, 0-9 or _): ")
-	newdirpath = os.path.join(chaptersdir, chaptername)
+	newdirpath = os.path.join(settings.chaptersdir, chaptername)
 	print("Creating new directory: "+newdirpath)
 	if not os.path.exists(newdirpath):
 		os.makedirs(newdirpath)
 	newfilepath = os.path.join(newdirpath,chaptername+".tex")
 	print("Creating new tex-file: "+newfilepath)
 	newfile = open(newfilepath, 'w')
+	print("% !TeX root = ../../"+settings.mainfile, file=newfile)
 	print("\\chapter{This is "+chaptername+"}\\label{ch:"+chaptername+"}\n", file=newfile)
 	print("\n\\ldots\n\n\n\n\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\


### PR DESCRIPTION
By adding the '% !TeX root = ../../thesis.tex' to the chapter files, TeXstudio (and possibly others) will detects 'thesis.tex' as the root file, so that features like pressing the compile button, label names, ... work correctly.

I've also solved a bug in the run.py script: the variable chaptersdir doesn't exist, so I replaced it by settings.chaptersdir.