### PR TITLE
Change erroneous \lbleed to \rbleed in \backcoverfooter

### DIFF
--- a/adsphd.cls
+++ b/adsphd.cls
@@ -1833,7 +1833,7 @@ without written permission from the publisher.
 \newcommand{\backcoverfooterXII}[1]{%
   % Bottom blue bar
   %\begin{textblock*}{\adsphdpaperwidth}(#1,222mm)
-  \begin{textblock*}{\adsphdpaperwidth+\lbleed+\rbleed}(#1-\lbleed,222mm)
+  \begin{textblock*}{\adsphdpaperwidth+\lbleed+\rbleed}(#1-\rbleed,222mm)
   %\begin{textblock*}{\adsphdpaperwidth}(0mm+#1,234mm)
   \textblockcolour{blueXIIdark}
   %\vspace{-\parskip}


### PR DESCRIPTION
The command \backcoverfooterXII currently seems to use the wrong bleed when drawing the blue bar at the bottom: compiling cover.tex with left bleed smaller than the right bleed leads to the blue bar at the bottom being drawn partially on the spine.

Signed-off-by: trldp <trldp@outlook.com>