### PR TITLE
Small fix to the title page to prevent additional background colour behind the logo

### DIFF
--- a/adsphd.cls
+++ b/adsphd.cls
@@ -1286,6 +1286,8 @@ De appendices kunnen desgevallend worden gebundeld in een apart boekdeel.
   %
   % Create logo box
   \begin{textblock*}{56mm}(10mm+#1,15mm)
+  % explicitly turn off block colour to prevent the coloured background from popping up due to misalignment of the logo
+  \textblockcolour{}
   \includegraphics[width=56mm,height=20mm]{image/KULEUVEN_LOGO_2012}
   \end{textblock*}
   %


### PR DESCRIPTION
The textbox containing the KU Leuven logo on the titlepage is also filled with a background colour.
When the logo does not perfectly align with the textbox, this introduces an additional border (as illustrated on the image below).
This small fix removes that background colour to avoid this.
![titlepage](https://user-images.githubusercontent.com/2634792/84748179-9234d280-afb8-11ea-8373-2a9afb23743b.png)
