### PR TITLE
set microtype protrusion to false in list of figures and tables

### DIFF
--- a/adsphd.cls
+++ b/adsphd.cls
@@ -991,7 +991,9 @@ LuaLaTeX or XeTeX}
   \cleardoublepage
   \phantomsection
   \addcontentsline{toc}{chapter}{\listfigurename}
+  \microtypesetup{protrusion=false}
   \listoffiguresorig
+  \microtypesetup{protrusion=true}
 }
 
 \let\listoftablesorig\listoftables
@@ -999,7 +1001,9 @@ LuaLaTeX or XeTeX}
   \cleardoublepage
   \phantomsection
   \addcontentsline{toc}{chapter}{\lotname}
+  \microtypesetup{protrusion=false}
   \listoftablesorig
+  \microtypesetup{protrusion=true}
 }
 
 \newcommand{\includeappendix}[1]{%


### PR DESCRIPTION
This is a fix for https://github.com/wannesm/adsphd/issues/67  where the dots in the list of figures protrude past the column.

The issue is resolved by temporarily disabling microtype protrusion before printing the table and re-enabling it afterward. This approach was already applied to the table of contents and has now been extended to the list of figures and the list of tables.