### PR TITLE
Add support for latexmk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ thesis.aux
 thesis.bbl
 thesis.blg
 thesis.dvi
+thesis.xdv
 thesis.lof
 thesis.log
 thesis.lot
@@ -28,6 +29,8 @@ thesis.ind
 thesis.run.xml
 thesis.synctex.gz
 thesis.ps
+thesis.fdb_latexmk
+*.fls
 cover.*
 s
 .force_rebuild

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -11,6 +11,8 @@ $pdf_mode = 4;
 $dvi_mode = 0;
 $postscript_mode = 0;
 
+# Modify this line to change which file to build
+# Remove if you want to build all .tex files
 @default_files = ("thesis");
 
 # Custom dependency and function for glossaries package 

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,0 +1,46 @@
+
+# Use pdflatex
+# $pdf_mode = 1;
+
+# Use XeLaTeX
+# $pdf_mode = 5;
+
+# Use LuaLaTeX (recommended for new documents: https://www.texdev.net/2024/11/05/engine-news-from-the-latex-project)
+$pdf_mode = 4;
+
+$dvi_mode = 0;
+$postscript_mode = 0;
+
+@default_files = ("thesis");
+
+# Custom dependency and function for glossaries package 
+add_cus_dep('glo', 'gls', 0, 'run_makeglossaries');
+add_cus_dep('acn', 'acr', 0, 'run_makeglossaries');
+
+# Custom dependency and function for nomencl package 
+add_cus_dep( 'nlo', 'nls', 0, 'run_makeindex' );
+
+
+push @generated_exts, 'glo', 'gls', 'glg';
+push @generated_exts, 'acn', 'acr', 'alg';
+$clean_ext .= ' %R.ist %R.xdy';
+
+sub run_makeindex {
+    system( "makeindex -s nomencl.ist -o \"$_[0].nls\" \"$_[0].nlo\"" );
+}
+
+sub run_makeglossaries {
+    my ($base_name, $path) = fileparse( $_[0] ); #handle -outdir param by splitting path and file, ...
+    pushd $path; # ... cd-ing into folder first, then running makeglossaries ...
+
+    if ( $silent ) {
+        # system "makeglossaries -q '$base_name'"; #unix
+        system "makeglossaries", "-q", "$base_name"; #windows
+    }
+    else {
+        # system "makeglossaries '$base_name'"; #unix
+        system "makeglossaries", "$base_name"; #windows
+    };
+
+    popd; # ... and cd-ing back again
+}

--- a/README.md
+++ b/README.md
@@ -72,9 +72,18 @@ The adsphd.cls class can be used directly by latex:
     pdflatex thesis
     pdflatex thesis
 
-Any other Latex build tool like latexmk, rubber, SCons, TeXShop or TeXWorks 
+Any other Latex build tool like rubber, SCons, TeXShop or TeXWorks 
 should also work out of the box (`makeindex` might not run by default in which
 case you will not see the glossary).
+
+Using latexmk
+--------------
+
+A `.latexmkrc`file is provided which adds support for the `nomencl` and `glossaries` packages.
+By default `thesis.tex` will be built with LuaLaTeX (other files will be ignored).
+This behavior can be changed by modifying the `$pdf_mode` and `@default_files` variables in `.latexmkrc`.
+
+In VSCode you can use the `latexmk` recipe of the `LaTeX Workshop` extension.
 
 Using the simple Python compile script
 --------------------------------------

--- a/adsphd.cls
+++ b/adsphd.cls
@@ -213,7 +213,12 @@
   \ifpdf
     \PassOptionsToPackage{plainpages=false,pdfpagelabels,bookmarks,breaklinks,pdfborder={0 0 0}}{hyperref}
   \else
-    \PassOptionsToPackage{plainpages=false,pdfpagelabels,ps2pdf,bookmarks,breaklinks,pdfborder={0 0 0}}{hyperref}
+    % XeTeX can generate .xdv files, which do not trigger the \ifpdf flag, but ps2pdf must not be set in that case
+    \ifXeTeX
+      \PassOptionsToPackage{plainpages=false,pdfpagelabels,bookmarks,breaklinks,pdfborder={0 0 0}}{hyperref}
+    \else
+      \PassOptionsToPackage{plainpages=false,pdfpagelabels,ps2pdf,bookmarks,breaklinks,pdfborder={0 0 0}}{hyperref}
+    \fi
   \fi
 \fi
 


### PR DESCRIPTION
This pull request adds `latexmk` support by adding a `.latexmkrc` file which takes care of the index and glossaries.
Some default values have also been added to ensure you can simply run `latexmk` without flags in the top directory and obtain a pdf:
 - The default engine is LuaLaTex (can be switched to pdflatex and XeLaTex if desired)
 - The default file is `thesis.tex`

`adsphd.cls` has a small fix for XeLaTeX support in the case `.xdv` files are generated (such as `latexmk` does for performance reasons).