### PR TITLE
Replace 2007-era protrusion fix with better 2018-era fix

### DIFF
--- a/adsphd.cls
+++ b/adsphd.cls
@@ -655,6 +655,17 @@
 \usepackage[titles]{tocloft}
 \renewcommand{\cftchapfont}{\sffamily\bfseries\selectfont}
 \renewcommand{\cftchappagefont}{\sffamily\bfseries\selectfont}
+%% Patch `tocloft' per https://tex.stackexchange.com/questions/172785/how-can-i-make-the-dots-in-a-toc-end-at-the-same-place
+\newcommand\cftdefaultafterpnum{\kern-1sp\kern1sp}
+\renewcommand\cftpartafterpnum{\cftdefaultafterpnum}
+\renewcommand\cftchapafterpnum{\cftdefaultafterpnum}
+\renewcommand\cftsecafterpnum{\cftdefaultafterpnum}
+\renewcommand\cftsubsecafterpnum{\cftdefaultafterpnum}
+\renewcommand\cftsubsubsecafterpnum{\cftdefaultafterpnum}
+\renewcommand\cftparaafterpnum{\cftdefaultafterpnum}
+\renewcommand\cftsubparaafterpnum{\cftdefaultafterpnum}
+\renewcommand\cftfigafterpnum{\cftdefaultafterpnum}
+\renewcommand\cfttabafterpnum{\cftdefaultafterpnum}
 
 % PAGE LAYOUT
 %\setlength{\textwidth}{12.5truecm}
@@ -975,9 +986,7 @@ LuaLaTeX or XeTeX}
   \cleardoublepage
   \phantomsection
   \addcontentsline{toc}{chapter}{\tocname}
-  \microtypesetup{protrusion=false}
   \tableofcontentsorig
-  \microtypesetup{protrusion=true}
 }
 
 \let\lstlistoflistingsorig\lstlistoflistings


### PR DESCRIPTION
Instead of disabling microtype protrusion entirely in Table of Contents (which was the advice in `microtype` documentation since Jul 2007), use cancelling kern pairs to disable it only where page numbers occur — this is the same approach used by LaTeX since Dec 2018 (and `microtype` documentation removed its old advice in May 2021) but the LaTeX fix is overwritten by `tocloft` (used by `adsphd`), so here we use `tocloft`'s after-page sockets to insert the same fix. Longer discussion at [https://tex.stackexchange.com/a/761017/206306](https://tex.stackexchange.com/a/761017/206306).